### PR TITLE
fix getpid() intrinsic for gfortran

### DIFF
--- a/src/smkinven/rdinvsrcs.f
+++ b/src/smkinven/rdinvsrcs.f
@@ -84,7 +84,7 @@ C...........   EXTERNAL FUNCTIONS and their descriptions:
         INTEGER*4       GETPID   
         LOGICAL         USEEXPGEO
 
-        EXTERNAL        CRLF, ENVINT, GETFLINE, GETFORMT, GETINVYR, GETPID,
+        EXTERNAL        CRLF, ENVINT, GETFLINE, GETFORMT, GETINVYR, 
      &                  JUNIT, FIND1, FIND1FIRST, FINDC,
      &                  CHKINT, STR2INT, INDEX1, BLKORCMT, SETENVVAR,
      &                  USEEXPGEO


### PR DESCRIPTION
issue for gfortran (does not show up with Intel fortran);

closes https://github.com/CEMPD/SMOKE/issues/29