### PR TITLE
String length differs with defined. It causes an error on GNU compilers.

### DIFF
--- a/src/emqa/wrrephdr.f
+++ b/src/emqa/wrrephdr.f
@@ -284,7 +284,7 @@ C...........   Local parameters
      &                              'SE Latitude      ',
      &                              'SE Longitude     ',
      &                              'GSPRO Description',
-     &                              'Boiler' / )
+     &                              'Boiler           ' / )
 
 C...........   Local variables that depend on module variables
         LOGICAL    LGEO1USE ( NGEOLEV1 )


### PR DESCRIPTION
Hi, I found this tiny "bug", that causes gfortran compiler to crash when i try to compile it.