### PR TITLE
Change laypoint to use the meteorological variables from the cell of residence

### DIFF
--- a/src/point/laypoint.f
+++ b/src/point/laypoint.f
@@ -1433,7 +1433,7 @@ C.....................  Compute derived met vars needed before layer assignments
      &                       TSFC( S ), DDZF( 1,S ), QV( 1,S ),
      &                       TA( 1,S ), UWIND( 1,S ), VWIND( 1,S ),
      &                       ZH( 1,S ), ZF( 1,S ), ZSTK( 1,S ),
-     &                       PRESF( 1 ), LSTK, LPBL, TSTK, WSTK,
+     &                       PRESF, LSTK, LPBL, TSTK, WSTK,
      &                       DTHDZ, WSPD, ZZF )
 
 C.....................  Retreive altitude from source characterisitcs and
@@ -1459,6 +1459,7 @@ C.....................  Compute pressures, use sigma values and surface pressure
                         PRESF( L ) = VGLVSXG( L ) *
      &                               ( PRSFC( S ) - VGTOP ) * CONVPA +
      &                               VGTOP * CONVPA
+
                     END DO
 
 C.....................  Convert surface pressure from Pa to mb
@@ -1466,18 +1467,18 @@ C.....................  Convert surface pressure from Pa to mb
 
 C.....................  Compute derived met vars needed before layer assignments
                     IF( FIREFLAG ) THEN
-                        CALL FIRE_PREPLM( EMLAYS, HMIX( S ), ZERO, PSFC,
+                        CALL FIRE_PREPLM( S, EMLAYS, HMIX( S ), ZERO, PSFC,
      &                           TSFC( S ), DDZF( 1,S ), QV( 1,S ),
      &                           TA( 1,S ), UWIND( 1,S ), VWIND( 1,S ),
      &                           ZH( 1,S ), ZF( 1,S ), ZSTK( 1,S ),
-     &                           PRESF( 1 ), LSTK, LPBL, TSTK, WSTK,
+     &                           PRESF, LSTK, LPBL, TSTK, WSTK,
      &                           DTHDZ, WSPD, ZZF )
                     ELSE
                         CALL PREPLM( EMLAYS, HMIX( S ), STKHT(S), PSFC,
      &                           TSFC( S ), DDZF( 1,S ), QV( 1,S ),
      &                           TA( 1,S ), UWIND( 1,S ), VWIND( 1,S ),
      &                           ZH( 1,S ), ZF( 1,S ), ZSTK( 1,S ),
-     &                           PRESF( 1 ), LSTK, LPBL, TSTK, WSTK,
+     &                           PRESF, LSTK, LPBL, TSTK, WSTK,
      &                           DTHDZ, WSPD, ZZF )
                     END IF
 
@@ -1511,7 +1512,7 @@ C.....................  Compute plume rise for this source, if needed
                                 TMPBFLX = BFLX( S )
                             END IF
 
-                            CALL FIRE_PLMRIS( EMLAYS, LPBL, LSTK,
+                            CALL FIRE_PLMRIS( S, EMLAYS, LPBL, LSTK,
      &                           HFX(S), HMIX(S), TMPBFLX, TSTK, USTMP,
      &                           DTHDZ, TA(1,S), WSPD, ZZF(0), ZH(1,S),
      &                           ZSTK(1,S), WSTK, ZTOP, ZBOT, ZPLM )
@@ -1521,7 +1522,7 @@ C.....................  Compute plume rise for this source, if needed
      &                           DTHDZ, TA(1,S), WSPD, ZZF(0), ZH(1,S),
      &                           ZSTK(1,S), WSTK, ZPLM )
                         END IF
-
+                        
 C.........................  Determine bottom and top heights of the plume
                         IF( IPVERT == 0 ) THEN
 
@@ -1598,7 +1599,7 @@ C.................  Allocate plume to layers
 
                       ENDIF
                     END IF
-
+                    
                     CALL FIRE_POSTPLM( EMLAYS, S, ZBOT, ZTOP, PRESF,
      &                                 LFULLHT, TEMPS, LHALFHT, TMPACRE,
      &                                 FPB1FLAG, LTOP, TFRAC )

--- a/src/point/laypoint.f
+++ b/src/point/laypoint.f
@@ -173,13 +173,13 @@ C.........  Allocatable dot-point surface grid coordinates
         REAL   , ALLOCATABLE :: DXVALS( :,: )   ! x values
         REAL   , ALLOCATABLE :: DYVALS( :,: )   ! y values
 
-C.........  Allocatable un-gridding matrices (uses bilinear interpolation)
-C           Dimensioned 4 by NSRC
-        INTEGER, ALLOCATABLE :: ND( :,: )     !  dot-point, cell indexes
-        INTEGER, ALLOCATABLE :: NX( :,: )     !  cross-point, cell indexes
-
-        REAL   , ALLOCATABLE :: CD( :,: )     !  dot-point, coefficients
-        REAL   , ALLOCATABLE :: CX( :,: )     !  cross-point, coefficients
+C.........  Allocatable un-gridding matrices
+        INTEGER, ALLOCATABLE :: ND( : )     !  records per cell (unused) 
+        INTEGER, ALLOCATABLE :: NX( : )     !  records per cell (unused)
+        INTEGER, ALLOCATABLE :: GD( : )     !  dot-point, cell index 
+        INTEGER, ALLOCATABLE :: GX( : )     !  cross-point, cell index
+        INTEGER, ALLOCATABLE :: SN( : )        ! record index (unused)
+        INTEGER, ALLOCATABLE :: INDX( : )      ! sorting index (unused)
 
 C.........  Output layer fractions, dimensioned NSRC, emlays
         REAL   , ALLOCATABLE :: LFRAC( :, : )
@@ -220,7 +220,7 @@ C...........   Logical names and unit numbers
         CHARACTER(16) DAYNAME   !  daily inventory file name
 
 C...........   Other local variables
-        INTEGER          I, J, K, L, L1, L2, S, T  ! counters and indices
+        INTEGER          I, J, K, L, L1, L2, S, T   ! counters and indices
 
         INTEGER          EMLAYS    ! number of emissions layers
         INTEGER          IOS       ! tmp i/o status
@@ -244,6 +244,10 @@ C...........   Other local variables
         INTEGER       :: STIME = 0 ! start time (HHMMSS)
         INTEGER          TSTEP     ! output time step
         INTEGER          IPVERT    ! plume vertical spread method
+        INTEGER          NEXCLD    ! number of sources excluded on grid
+        INTEGER          COL       ! column number
+        INTEGER          ROW       ! row number
+        INTEGER          NCEL      ! cell index number
 
         REAL             X, Y, P, Q
         REAL             DM, HT, TK, VE, FL  ! tmp stack parameters
@@ -915,14 +919,10 @@ C.............  Layer fractions for all sources
             LFRAC = 0.0
 
 C.............  Allocate ungridding arrays
-            ALLOCATE( ND( 4,NSRC ), STAT=IOS )
-            CALL CHECKMEM( IOS, 'ND', PROGNAME )
-            ALLOCATE( NX( 4,NSRC ), STAT=IOS )
-            CALL CHECKMEM( IOS, 'NX', PROGNAME )
-            ALLOCATE( CD( 4,NSRC ), STAT=IOS )
-            CALL CHECKMEM( IOS, 'CD', PROGNAME )
-            ALLOCATE( CX( 4,NSRC ), STAT=IOS )
-            CALL CHECKMEM( IOS, 'CX', PROGNAME )
+            ALLOCATE( GD( NSRC ), STAT=IOS )
+            CALL CHECKMEM( IOS, 'GD', PROGNAME )
+            ALLOCATE( GX( NSRC ), STAT=IOS )
+            CALL CHECKMEM( IOS, 'GX', PROGNAME )
 
 C.............  Allocate per-layer arrays from 1:EMLAYS
             ALLOCATE( WSPD( EMLAYS ), STAT=IOS )
@@ -948,9 +948,19 @@ C.............  Allocate array for tmp gridded, layered cross-point met data
             ALLOCATE( DBUF( NDOTS,NLAYS ), STAT=IOS )
             CALL CHECKMEM( IOS, 'DBUF', PROGNAME )
 
+C.........  Allocate memory so that we can use the GENPTCEL
+            ALLOCATE( NX( METNGRID ), STAT=IOS )
+            CALL CHECKMEM( IOS, 'NX', PROGNAME )
+            ALLOCATE( ND( NDOTS ), STAT=IOS )
+            CALL CHECKMEM( IOS, 'ND', PROGNAME )
+            ALLOCATE( INDX( NSRC ), STAT=IOS )
+            CALL CHECKMEM( IOS, 'INDX', PROGNAME )
+            ALLOCATE( SN( NSRC ), STAT=IOS )
+            CALL CHECKMEM( IOS, 'SN', PROGNAME )
 
-C.............  If variable grid, allocate latitude and longitude arrays
+C.............  Compute un-gridding matrices for dot and cross point met data
             IF( GFLAG ) THEN
+C.............  If variable grid, allocate latitude and longitude arrays
                 ALLOCATE( XXVALS( METNCOLS,METNROWS ), STAT=IOS )
                 CALL CHECKMEM( IOS, 'XXVALS', PROGNAME )
                 ALLOCATE( XYVALS( METNCOLS,METNROWS ), STAT=IOS )
@@ -959,18 +969,15 @@ C.............  If variable grid, allocate latitude and longitude arrays
                 CALL CHECKMEM( IOS, 'DXVALS', PROGNAME )
                 ALLOCATE( DYVALS( METNCOLS+1,METNROWS+1 ), STAT=IOS )
                 CALL CHECKMEM( IOS, 'DYVALS', PROGNAME )
-            END IF
 
-C.............  Compute un-gridding matrices for dot and cross point met data
-            IF( GFLAG ) THEN
+C.............  Determine grid cells for these coordinate locations
+C.............  Determine the X & Y values from the lat and lon
                 CALL SAFE_READ3( TNAME, 'LON', 1, 0, 0, DXVALS )
                 CALL SAFE_READ3( TNAME, 'LAT', 1, 0, 0, DYVALS )
 
                 CALL CONVRTXY( (METNCOLS+1), (METNROWS+1), GDTYP, GRDNM,
      &                         P_ALP, P_BET, P_GAM, XCENT, YCENT,
      &                         DXVALS, DYVALS )
-                CALL UNGRIDBV( METNCOLS+1, METNROWS+1, DXVALS, DYVALS,
-     &                         NSRC, XLOCA, YLOCA, ND, CD )
 
                 CALL SAFE_READ3( CNAME, 'LON', 1, 0, 0, XXVALS )
                 CALL SAFE_READ3( CNAME, 'LAT', 1, 0, 0, XYVALS )
@@ -978,16 +985,14 @@ C.............  Compute un-gridding matrices for dot and cross point met data
                 CALL CONVRTXY( METNCOLS, METNROWS, GDTYP, GRDNM,
      &                         P_ALP, P_BET, P_GAM, XCENT, YCENT,
      &                         XXVALS, XYVALS )
-                CALL UNGRIDBV( METNCOLS, METNROWS, XXVALS, XYVALS,
-     &                         NSRC, XLOCA, YLOCA, NX, CX )
-            ELSE
-                CALL UNGRIDBD1( METNCOLS+1, METNROWS+1,
-     &                        XORIGDG, YORIGDG, XCELLDG, YCELLDG,
-     &                        NSRC, XLOCA, YLOCA, ND, CD )
 
-                CALL UNGRIDBD1( METNCOLS, METNROWS,
-     &                        METXORIG, METYORIG, XCELL, YCELL,
-     &                        NSRC, XLOCA, YLOCA, NX, CX )
+                CALL GENPTVCEL( NSRC, NDOTS, DXVALS, DYVALS, NEXCLD, ND,
+     &                      INDX, GD, SN )
+                CALL GENPTVCEL( NSRC, METNGRID, XXVALS, XYVALS, NEXCLD, NX,
+     &                      INDX, GX, SN )
+            ELSE
+                CALL GENPTCEL( NSRC, METNGRID, XLOCA, YLOCA, NEXCLD, NX,
+     &                      INDX, GX, SN )
             END IF
 
 C.............  Read time-independent ZF and ZH for non-hydrostatic Met data
@@ -1017,12 +1022,12 @@ C.................  Open GRIDCRO3D file and check that it matches other met file
                 CALL GET_VARIABLE_NAME( 'ZH', VNAME )
                 CALL SAFE_READ3( GNAME, VNAME, ALLAYS3, SDATE3D,
      &                           STIME3D, XBUF )
-                CALL BMATVEC( METNGRID, NSRC, EMLAYS, NX, CX, XBUF, ZH )
+                CALL METCELL_3D( METNGRID, NSRC, EMLAYS, GX, XBUF, ZH )
 
                 CALL GET_VARIABLE_NAME( 'ZF', VNAME )
                 CALL SAFE_READ3( GNAME, VNAME, ALLAYS3, SDATE3D,
      &                           STIME3D, XBUF )
-                CALL BMATVEC( METNGRID, NSRC, EMLAYS, NX, CX, XBUF, ZF )
+                CALL METCELL_3D( METNGRID, NSRC, EMLAYS, GX, XBUF, ZF )
 
 C.................  Pre-process ZF and ZH to compute DDZH and DDZF
                 CALL COMPUTE_DELTA_ZS
@@ -1201,10 +1206,10 @@ C.............  Compute per-source heights
             IF( .NOT. XFLAG .AND. .NOT. ZSTATIC ) THEN
 
                 CALL SAFE_READ3( XNAME,'ZH',ALLAYS3,JDATE,JTIME,XBUF )
-                CALL BMATVEC( METNGRID, NSRC, EMLAYS, NX, CX, XBUF, ZH )
+                CALL METCELL_3D( METNGRID, NSRC, EMLAYS, GX, XBUF, ZH )
 
                 CALL SAFE_READ3( XNAME,'ZF',ALLAYS3,JDATE,JTIME,XBUF )
-                CALL BMATVEC( METNGRID, NSRC, EMLAYS, NX, CX, XBUF, ZF )
+                CALL METCELL_3D( METNGRID, NSRC, EMLAYS, GX, XBUF, ZF )
 
 C.................  Pre-process ZF and ZH to compute DDZH and DDZF
                 CALL COMPUTE_DELTA_ZS
@@ -1214,38 +1219,53 @@ C.................  Pre-process ZF and ZH to compute DDZH and DDZF
 C.............  Read and transform meteorology:
             IF ( .NOT. XFLAG ) THEN
             CALL SAFE_READ3( SNAME, 'HFX', ALLAYS3, JDATE, JTIME, XBUF )
-            CALL BMATVEC( METNGRID, NSRC, 1, NX, CX, XBUF, HFX )
+            CALL METCELL_2D( METNGRID, NSRC, GX, XBUF, HFX)
 
             CALL SAFE_READ3( SNAME, 'PBL', ALLAYS3, JDATE, JTIME, XBUF )
-            CALL BMATVEC( METNGRID, NSRC, 1, NX, CX, XBUF, HMIX )
+            CALL METCELL_2D( METNGRID, NSRC, GX, XBUF, HMIX)
 
             CALL GET_VARIABLE_NAME( 'TGD', VNAME )
             CALL SAFE_READ3( SNAME, VNAME, ALLAYS3, JDATE, JTIME, XBUF )
-            CALL BMATVEC( METNGRID, NSRC, 1, NX, CX, XBUF, TSFC )
+            CALL METCELL_2D( METNGRID, NSRC, GX, XBUF, TSFC)
 
             CALL SAFE_READ3( SNAME, 'USTAR', ALLAYS3, JDATE,JTIME,XBUF )
-            CALL BMATVEC( METNGRID, NSRC, 1, NX, CX, XBUF, USTAR )
+            CALL METCELL_2D( METNGRID, NSRC, GX, XBUF, USTAR)
 
             CALL SAFE_READ3( SNAME, 'PRSFC', ALLAYS3, JDATE,JTIME,XBUF )
-            CALL BMATVEC( METNGRID, NSRC, 1, NX, CX, XBUF, PRSFC )
+            CALL METCELL_2D( METNGRID, NSRC, GX, XBUF, PRSFC)
 
             CALL SAFE_READ3( XNAME, 'TA', ALLAYS3, JDATE, JTIME, XBUF )
-            CALL BMATVEC( METNGRID, NSRC, EMLAYS, NX, CX, XBUF, TA )
+            CALL METCELL_3D( METNGRID, NSRC, EMLAYS, GX, XBUF, TA )
 
             CALL SAFE_READ3( XNAME, 'QV', ALLAYS3, JDATE, JTIME, XBUF )
-            CALL BMATVEC( METNGRID, NSRC, EMLAYS, NX, CX, XBUF, QV )
+            CALL METCELL_3D( METNGRID, NSRC, EMLAYS, GX, XBUF, QV )
 
             CALL SAFE_READ3( XNAME, 'PRES', ALLAYS3, JDATE, JTIME,XBUF )
-            CALL BMATVEC( METNGRID, NSRC, EMLAYS, NX, CX, XBUF, PRES )
+            CALL METCELL_3D( METNGRID, NSRC, EMLAYS, GX, XBUF, PRES )
 
             CALL SAFE_READ3( XNAME, 'DENS', ALLAYS3, JDATE, JTIME,XBUF )
-            CALL BMATVEC( METNGRID, NSRC, EMLAYS, NX, CX, XBUF, DENS )
+            CALL METCELL_3D( METNGRID, NSRC, EMLAYS, GX, XBUF, DENS )
 
-            CALL SAFE_READ3( DNAME, 'UWIND', ALLAYS3, JDATE,JTIME,DBUF )
-            CALL BMATVEC( NDOTS, NSRC, EMLAYS, ND, CD, DBUF, UWIND )
+C.............  Read the low left dot and interpolate with the upper right
+C.............  Shift over one column
+            IF ( .NOT. GFLAG) THEN
+                DO S = 1, NSRC
+                    NCEL = GX( S )
+                    GD( S ) = NCEL + 1 
+                END DO
+            END IF
+            CALL SAFE_READ3( DNAME, 'UWINDC', ALLAYS3, JDATE,JTIME,DBUF )
+            CALL METDOT_3D( NDOTS, NSRC, EMLAYS, GX, GD, DBUF, UWIND )
 
-            CALL SAFE_READ3( DNAME, 'VWIND', ALLAYS3, JDATE,JTIME,DBUF )
-            CALL BMATVEC( NDOTS, NSRC, EMLAYS, ND, CD, DBUF, VWIND )
+C.............  Shift over one row
+            IF ( .NOT. GFLAG) THEN
+                DO S = 1, NSRC
+                    NCEL = GX( S )
+                    GD( S ) = NCEL + NCOLS
+                END DO
+            END IF
+            CALL SAFE_READ3( DNAME, 'VWINDC', ALLAYS3, JDATE,JTIME,DBUF )
+            CALL METDOT_3D( NDOTS, NSRC, EMLAYS, GX, GD, DBUF, VWIND )
             END IF
 
 C.............  Precompute constants before starting source loop
@@ -1907,6 +1927,99 @@ C----------------------------------------------------------------------
             END DO  ! End processing for intermediate layer height calcs
 
             END SUBROUTINE COMPUTE_DELTA_ZS
+
+C----------------------------------------------------------------------
+
+C.............  This internal subprogram computes assigns the grid cell
+C                value to the source
+            SUBROUTINE METCELL_2D( M, N, IX, V, Y )
+
+C.............  Subprogram arguments
+            INTEGER, INTENT (IN)  :: M              ! length of input
+            INTEGER, INTENT (IN)  :: N              ! length of output array
+            INTEGER, INTENT (IN)  :: IX( N )        ! index array
+            REAL,    INTENT (IN)  :: V( M )         ! input vector
+            REAL,    INTENT (OUT) :: Y( N )         ! output vector
+C.............  Local variables
+            INTEGER S, J
+
+C----------------------------------------------------------------------
+
+            DO S = 1, N
+               
+                J = IX( S ) 
+                Y( S ) = V( J )
+
+            END DO
+
+            END SUBROUTINE METCELL_2D
+
+C----------------------------------------------------------------------
+
+C.............  This internal subprogram computes assigns the grid cell
+C                value to the source
+            SUBROUTINE METCELL_3D( M, N, P, IX, V, Y )
+
+C.............  Subprogram arguments
+            INTEGER, INTENT (IN)  :: M              ! length of input
+            INTEGER, INTENT (IN)  :: N              ! length of output array
+            INTEGER, INTENT (IN)  :: P              ! number of layers
+            INTEGER, INTENT (IN)  :: IX( N )        ! index array
+            REAL,    INTENT (IN)  :: V( M, P )         ! input vector
+            REAL,    INTENT (OUT) :: Y( P, N )         ! output vector
+C.............  Local variables
+            INTEGER S, J, L
+
+C----------------------------------------------------------------------
+
+            DO S = 1, N
+               
+                J = IX( S ) 
+
+                DO L = 1, P
+
+                    Y( L, S ) = V( J, L )
+
+                END DO
+
+            END DO
+
+            END SUBROUTINE METCELL_3D
+
+C.............  This internal subprogram assigns the grid cell 
+C                value to the source from the interpolated grid dot
+            SUBROUTINE METDOT_3D( M, N, P, JX, KX, V, Y )
+
+C.............  Subprogram arguments
+            INTEGER, INTENT (IN)  :: M              ! length of input
+            INTEGER, INTENT (IN)  :: N              ! length of output array
+            INTEGER, INTENT (IN)  :: P              ! number of layers
+            INTEGER, INTENT (IN)  :: JX( N )        ! index array dot 1
+            INTEGER, INTENT (IN)  :: KX( N )        ! index array dot 2
+            REAL,    INTENT (IN)  :: V( M, P )         ! input vector
+            REAL,    INTENT (OUT) :: Y( P, N )         ! output vector
+C.............  Local variables
+            INTEGER S, J, K, L
+            REAL LL, UR
+
+C----------------------------------------------------------------------
+
+            DO S = 1, N
+               
+                J = JX( S )
+                K = KX( S ) 
+
+                DO L = 1, P
+
+                    LL = V( J, L )
+                    UR = V( K, L )
+                    Y( L, S ) = 0.5 * (LL + UR)
+
+                END DO
+
+            END DO
+
+            END SUBROUTINE METDOT_3D
 
         END PROGRAM LAYPOINT
 


### PR DESCRIPTION
Replaces the bi-linear interpolation method for associating meteorological values with the cell of residence method used in CMAQ.
Interpolates wind speed from the cell faces of UWINDC and VWINDC, replacing the single dot wind speed.