### PR TITLE
Use NINT() instead of INT() in chkgrid.f origin checking

### DIFF
--- a/src/lib/chkgrid.f
+++ b/src/lib/chkgrid.f
@@ -196,9 +196,9 @@ C.............  Check settings that must be consistent for grids and subgrids
 C.................  Ensure that origins are compatible with each other by
 C                   making sure they line up based on the cell sizes
                 CHK_X  = ( X0 - XORIG ) / XCELL
-                CHK_X  = CHK_X - INT( CHK_X )
+                CHK_X  = CHK_X - NINT( CHK_X )
                 CHK_Y  = ( Y0 - YORIG ) / YCELL
-                CHK_Y  = CHK_Y - INT( CHK_Y )
+                CHK_Y  = CHK_Y - NINT( CHK_Y )
                 IF( DABS( CHK_X ) > 0.001D0  .OR.
      &              DABS( CHK_Y ) > 0.001D0       ) THEN
                     SFLAG = .TRUE.


### PR DESCRIPTION
Changed chkgrid.f check origin test to use NINT(), instead of INT(), to prevent failure for cases where CHK_X/CHK_Y is a float slightly below the value of the next rounded-up integer.

Consider this case that will currently fail:
X0 =     996000
Y0 =     256000    
XORIG =     408000.
YORIG =    -216000.     
XCELL =     1333.33337
YCELL =     1333.33337  

(Note, I am aware that the grid resolution is probably considered unusual.)
